### PR TITLE
Downgrade Microsoft.CodeAnalysis.CSharp package version

### DIFF
--- a/DisposableHelpers.SourceGenerators/DisposableHelpers.SourceGenerators.csproj
+++ b/DisposableHelpers.SourceGenerators/DisposableHelpers.SourceGenerators.csproj
@@ -21,7 +21,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all" Pack="false" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" Pack="false" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
#### PR Classification
Package version downgrade.

#### PR Summary
This pull request downgrades the `Microsoft.CodeAnalysis.CSharp` package version from `4.13.0` to `4.12.0` in the project file. 
- `DisposableHelpers.SourceGenerators.csproj`: Changed `Microsoft.CodeAnalysis.CSharp` version from `4.13.0` to `4.12.0`.
